### PR TITLE
fix: add shader placeholder to prevent jump

### DIFF
--- a/src/components/ShaderComponent.js
+++ b/src/components/ShaderComponent.js
@@ -22,6 +22,6 @@ export const ShaderComponent = () => {
     }, [])
     return <canvas className="shader-canvas" ref={canvasRef} />
   } else {
-    return <></>
+    return <div className="shader-placeholder" />
   }
 }

--- a/src/components/ShaderComponent.js
+++ b/src/components/ShaderComponent.js
@@ -22,6 +22,6 @@ export const ShaderComponent = () => {
     }, [])
     return <canvas className="shader-canvas" ref={canvasRef} />
   } else {
-    return <div className="shader-placeholder" />
+    return <div className="shader-placeholder" key="shader-placeholder" />
   }
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -85,7 +85,7 @@ button {
   background-color: var(--ifm-color-emphasis-200) !important;
 }
 
-.shader-canvas {
+.shader-canvas, .shader-placeholder {
   top: 0;
   backface-visibility: hidden;
   perspective: 1000;
@@ -298,13 +298,13 @@ table tr {
 }
 
 @media only screen and (max-width: 1024px) {
-  .shader-canvas {
+  .shader-canvas, .shader-placeholder {
     height: 412px;
   }
 }
 
 @media only screen and (max-width: 800px) {
-  .shader-canvas {
+  .shader-canvas, .shader-placeholder {
     height: 388px;
   }
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,7 +11,7 @@ export default function Home() {
   return (
     <Layout>
       <ShaderComponent />
-      <div>
+      <div key="homepage-logo-wrapper">
         <HomepageLogo className={styles.logoText} />
         <h2 className={styles.headerSubtitle}>FOR DEVELOPERS</h2>
       </div>


### PR DESCRIPTION
love the docs! i noticed that while the shader/canvas is loading, the content shifts once the shader loads, this should prevent that from happening. I was not able to test it due to a bug in running the docs:

<img width="1276" alt="Screen Shot 2021-10-19 at 4 57 07 PM" src="https://user-images.githubusercontent.com/11803153/137996449-d256305f-ef70-4486-9ae0-bfe57b0e5b66.png">

