### PR TITLE
Fixed some minor grammar and typos

### DIFF
--- a/docs/developer-tools/nft-rendering/nft-hooks/usenftcontent.mdx
+++ b/docs/developer-tools/nft-rendering/nft-hooks/usenftcontent.mdx
@@ -8,7 +8,7 @@ sidebar_position: 4
 
 ---
 
-This hook makes a request to fetch content based on a NFT's `contentURI`.
+This hook makes a request to fetch content based on an NFT's `contentURI`.
 
 Most metadata servers allow remote JSON fetches, including all ZORA NFTs. There is a chance this request could fail. 
 Requests are set with a 10 second timeout to allow showing the user

--- a/docs/developer-tools/nft-rendering/nft-hooks/usenftmetadata.mdx
+++ b/docs/developer-tools/nft-rendering/nft-hooks/usenftmetadata.mdx
@@ -8,7 +8,7 @@ sidebar_position: 3
 
 ---
 
-This hook makes a request to fetch metadata from a NFT's `metadataURI`.
+This hook makes a request to fetch metadata from an NFT's `metadataURI`.
 
 Most metadata servers allow for remote JSON fetches, however, there is a chance this request could fail.
 Requests are set with a 10 second timeout to allow showing the user an error message

--- a/docs/developer-tools/zdk/zora-nfts.mdx
+++ b/docs/developer-tools/zdk/zora-nfts.mdx
@@ -8,9 +8,9 @@ Provides read and write access to the ZORA NFT contracts
 
 ---
 
-NFTs minted out of ZORA are known as ZORA NFTs (zNFT) and are also reffered to as `media`. More details about the ZORA smart contracts can be found [here](../../smart-contracts/zora-contracts). 
+NFTs minted out of ZORA are known as ZORA NFTs (zNFT) and are also referred to as `media`. More details about the ZORA smart contracts can be found [here](../../smart-contracts/zora-contracts). 
 
-To instantiate the module, an ethers.js `Signer` or `Provider`, must be passed to the constructor
+To instantiate the module, an ethers.js `Signer` or `Provider` must be passed to the constructor
 as well as the `chainID`.
 ZORA currently supports Ethereum Mainnet (1) and Rinkeby Testnet (4).
 
@@ -60,7 +60,7 @@ For more details on connecting to a user's wallet with Metamask or WalletConnect
 ---
 
 All the functions that are able to read data from the ZORA NFT smart contracts.
-We recommend using the using the [NFT Rendering](../nft-rendering/introduction) and [Zora Indexer](../indexer/introduction) sections if you only want to get NFT data.
+We recommend using the [NFT Rendering](../nft-rendering/introduction) and [Zora Indexer](../indexer/introduction) sections if you only want to get NFT data.
 
 ### fetchContentHash
 

--- a/docs/guides/minting-znfts.mdx
+++ b/docs/guides/minting-znfts.mdx
@@ -7,7 +7,7 @@ title: Mint an NFT
 
 ---
 
-To create new ZORA NFT using the ZDK, you must call the `mint` function. The `mint` function on a `Zora` instance expects two parameters: `MediaData` and `BidShares`
+To create a new ZORA NFT using the ZDK, you must call the `mint` function. The `mint` function on a `Zora` instance expects two parameters: `MediaData` and `BidShares`
 
 ## MediaData
 

--- a/docs/smart-contracts/intro.mdx
+++ b/docs/smart-contracts/intro.mdx
@@ -112,7 +112,7 @@ This means that a user will only need to approve each token contract to ZORA V3 
 ### Approving Modules
 Users can either approve a single ZORA module or selectively batch approve certain modules. 
 Every time a new module is added to the protocol a user must opt in and approve the newly added module to access to their tokens.
-Approving a module means that all tokens that have been approved to the Trasnfer Helpers will be able to be accessed by that module.
+Approving a module means that all tokens that have been approved to the Transfer Helpers will be able to be accessed by that module.
 
 #### setApprovalForModule
 Approves a single module to access a user's tokens.

--- a/docs/smart-contracts/modules/Asks/asks_1.1.mdx
+++ b/docs/smart-contracts/modules/Asks/asks_1.1.mdx
@@ -84,16 +84,16 @@ struct Ask {
 
 ### Finders Fee
 
-The Finders Fee is the amount offered to the party that helped matched the buyer to the NFT.
+The Finders Fee is the amount offered to the party that helped match the buyer to the NFT.
 For example, a user creates an `ask` for one of the NFTs in their wallet. 
-If a finders fee was specified, then the interface that helped matched the NFT to the buyer could be entitled to that amount.
+If a finders fee was specified, then the interface that helped match the NFT to the buyer could be entitled to that amount.
 Note that the Finders Fee is only charged if a buyer fills the `ask` on an NFT.
 
 <br/> 
 
 ### Honoring Royalties
 Whenever an `ask` is filled, the `Ask V1 Module` respects any royalties in this [Royalty Registery](https://royaltyregistry.xyz/lookup) created by Manifold.
-If your NFT contract doesn't currenctly support royalties, the owner address of an NFT contract is able to manually set the royalty in the registry.
+If your NFT contract doesn't currently support royalties, the owner address of an NFT contract is able to manually set the royalty in the registry.
 
 To calculate the percentage of a Royalty you can call `getRoyaltyView` on the Royalty engine with the token contract address, token id, and a value of 1e18 (1 ETH in wei) to get the splits and calculate the percentages based on the response.
 <br/> 

--- a/docs/smart-contracts/modules/Asks/asks_1.1.mdx
+++ b/docs/smart-contracts/modules/Asks/asks_1.1.mdx
@@ -101,7 +101,7 @@ To calculate the percentage of a Royalty you can call `getRoyaltyView` on the Ro
 ### Read Functions 
 
 #### askForNFT
-A public mapping that returns an `ask` given a NFT token contract address and token id. 
+A public mapping that returns an `ask` given an NFT token contract address and token id. 
 Note that there can only ever be one `ask` open for an NFT at a time.
 
 `mapping(address => mapping(uint256 => Ask)) public askForNFT;`


### PR DESCRIPTION
While I was reading through the docs I came across a few typos that I fixed along the way.

I also changed any instances of 'a NFT' to 'an NFT' for better readability and consistency throughout the docs. The latter was used much more frequently.