### PR TITLE
Add links to contract metadata format

### DIFF
--- a/docs/smart-contracts/creator-tools/DropMetadataRenderer.mdx
+++ b/docs/smart-contracts/creator-tools/DropMetadataRenderer.mdx
@@ -9,7 +9,7 @@ Whenever a `tokenURI` is called on an NFT contract it is forwarded to this contr
 View the source contract code [here](https://github.com/ourzora/zora-drops-contracts/blob/main/src/metadata/DropMetadataRenderer.sol) and the list of deployed contract addresses [here](https://github.com/ourzora/zora-drops-contracts/tree/main/deployments).
 
 - `baseURI`: A common base path that all the assets share and can append the tokenId to the end to get the metadata for an NFT.
-- `contractURI`: A resource for getting metadata for the contract.
+- `contractURI`: A resource for getting metadata for the contract. Follows the contract-level metadata format described [here](https://docs.opensea.io/docs/contract-level-metadata).
 - `provenanceHash`: A hash that is used to prove that the order of the images and metadata was set pre-mint, and was not manipulated.
 - `target`: The address of the NFT contract to get data for.
 

--- a/docs/smart-contracts/creator-tools/DropMetadataRenderer.mdx
+++ b/docs/smart-contracts/creator-tools/DropMetadataRenderer.mdx
@@ -14,7 +14,7 @@ View the source contract code [here](https://github.com/ourzora/zora-drops-contr
 - `target`: The address of the NFT contract to get data for.
 
 ## updateMetadataBase
-Updates to update either the baseURI or contractURI. 
+Updates the baseURI and contractURI.
 ```
 function updateMetadataBase(
     address target,
@@ -24,7 +24,7 @@ function updateMetadataBase(
 ```
 
 ## updateMetadataBaseWithDetails
-Updates the metadata base URI, extension, contract URI and freezing detailsUpdate metadata base URI, extension, contract URI and freezing detailsUpdate
+Updates the metadata base URI, extension, contract URI and freezing details.
 
 ```
 function updateMetadataBaseWithDetails(

--- a/docs/smart-contracts/creator-tools/ZoraNFTCreator.mdx
+++ b/docs/smart-contracts/creator-tools/ZoraNFTCreator.mdx
@@ -60,7 +60,7 @@ Note, not all of these fields can be changed after creating the contract.
 - `royaltyBPS`: BPS for on-chain royalties (cannot be changed)
 - `fundsRecipient`: Recipient for sales and royalties
 - `metadataURIBase`: URI Base for metadata
-- `metadataContractURI`: URI for contract metadata
+- `metadataContractURI`: URI for [contract metadata](https://docs.opensea.io/docs/contract-level-metadata)
 
 ```
 function createDrop(


### PR DESCRIPTION
I had a difficult time figuring out the required format for contract-level metadata in the `DropMetaDataRenderer` and `ZoraNFTCreator` contracts. Here are a few updates to the docs. 

- Add links to OpenSea's [contract metadata](https://docs.opensea.io/docs/contract-level-metadata) guide.
- Clean up a typo in the `updateMetadataBaseWithDetails` description.
- Clarify that `updateMetadataBase` will update _both_ `baseURI` and `contractURI`.