### PR TITLE
Add Goerli contract addresses

### DIFF
--- a/docs/smart-contracts/creator-tools/intro.mdx
+++ b/docs/smart-contracts/creator-tools/intro.mdx
@@ -26,7 +26,7 @@ The create proxy is the main contract that is used to interact with the latest d
 | **Network**       | **Address**                                |
 |-------------------|--------------------------------------------|
 | Ethereum - 1      | 0xf74b146ce44cc162b601dec3be331784db111dc1 |
-| Goerli - 5    | 0xb9583D05Ba9ba8f7F14CCEe3Da10D2bc0A72f519 |
+| Goerli - 5        | 0xb9583D05Ba9ba8f7F14CCEe3Da10D2bc0A72f519 |
 
 ## Main Create Contracts
 The most important contracts are:

--- a/docs/smart-contracts/intro.mdx
+++ b/docs/smart-contracts/intro.mdx
@@ -51,6 +51,14 @@ Source code for all ZORA V3 contracts can be found in this [GitHub repository](h
 | ERC-20 TransferHelper   | 0x408AbC192a5e9696085EBaFC7C5A88e19e66241b |
 | Protocol Fee Settings   | 0x8Ecd14bd28bf992B6d0595B3E35d5C206e2e2dbb |
 
+##### Goerli - 5
+| **Contract**            | **Address**                                |
+| ------------            | ------------------------------------------ |
+| Module Manager          | 0x9458E29713B98BF452ee9B2C099289f533A5F377 |
+| ERC-721 TransferHelper  | 0xd1adAF05575295710dE1145c3c9427c364A70a7f |
+| ERC-20 TransferHelper   | 0x53172d999a299198a935f9E424f9f8544e3d4292 |
+| Protocol Fee Settings   | 0x5f7072E1fA7c01dfAc7Cf54289621AFAaD2184d0 |
+
 
 ##### Mumbai - 80001
 | **Contract**            | **Address**                                |

--- a/docs/smart-contracts/modules/Asks/asks_1.1.mdx
+++ b/docs/smart-contracts/modules/Asks/asks_1.1.mdx
@@ -28,6 +28,7 @@ You can view all of the `Ask V1.1 Module` contract code in this [GitHub Repo](ht
 | ----------------- | ------------------------------------------ |
 | Ropsten - 3       | 0x3e80102228295fFD120990d54e954C473EDE7280 |
 | Rinkeby - 4       | 0xA98D3729265C88c5b3f861a0c501622750fF4806 |
+| Goerli - 5        | 0xd8be3E8A8648c4547F06E607174BAC36f5684756 |
 | Mumbai - 80001    | 0xCe6cEf2A9028e1C3B21647ae3B4251038109f42a |
 
 <br/>

--- a/docs/smart-contracts/modules/Asks/intro.mdx
+++ b/docs/smart-contracts/modules/Asks/intro.mdx
@@ -37,6 +37,12 @@ You can view the code for all `Asks Modules` in this [GitHub Repo](https://githu
 | CoreETH            | 0xA8389b0FBe3508bB10925D9f0C1618d0DaF54c74 |
 | CoreERC20          | Soon ™️ |
 
+##### Goerli - 5
+| **Contract**       | **Address**                                |
+| -------------------|--------------------------------------------|
+| CoreETH            | Soon ™️ |
+| CoreERC20          | Soon ™️ |
+
 
 
 ## Asks Module Variants

--- a/docs/smart-contracts/modules/Offers/offers_1.0.mdx
+++ b/docs/smart-contracts/modules/Offers/offers_1.0.mdx
@@ -25,6 +25,10 @@ You can view all of the `Offers V1.0 Module` contract code in this [GitHub Repo]
 |----------------|--------------------------------------------|
 | Rinkeby - 4    | 0x1240ef9f9c56ee981d10cffc6ba5807b6c7fecaa |
 
+| **Network**    | **Address**                                |
+|----------------|--------------------------------------------|
+| Goerli - 5     | 0x3a98377E8e67D01a3D21E30eCE6A4703eeB4d25a |
+
 
 ## Offer Structure
 

--- a/docs/smart-contracts/modules/ReserveAuctions/intro.mdx
+++ b/docs/smart-contracts/modules/ReserveAuctions/intro.mdx
@@ -53,6 +53,17 @@ You can view all of the code for the `Reserve Auction Modules` in this [GitHub R
 <!-- | ListingETH         | 0x665814dA60D1Ddc23Fa1F69C1F5B5CAF63ab24b3 |
 | ListingERC20       | 0x7a91CfC8C1Aec9EfdBaaCb47C6D41268524D47D4 | -->
 
+##### Goerli - 5
+| **Contract**       | **Address**                                |
+| -------------------|--------------------------------------------|
+| CoreETH            | 0x2506d9f5a2b0e1a2619bcce01cd3e7c289a13163 |
+| CoreERC20          | 0x1ee71c10e7dd6c7fbdc891de4e902e041e1f5d33 |
+| FindersETH         | 0x29a6237e646a5a189db197a48cb96fa7944a32a2 |
+| FindersERC20       | 0x36ab5200426715a9dd414513912970cb7d659b3c |
+
+<!-- | ListingETH         | 0xfcebe0788d5772df2cbcf5079815de98a4d62b09 |
+| ListingERC20       | 0x517f7721f3c3762f7048e03919761e027d900082 | -->
+
 
 ## Reserve Auction Variants
 There are several variants for the `Reserve Auction`. Each variant comes with different features and associated gas costs.


### PR DESCRIPTION
**What** — Add deployed contract addresses for Goerli testnet
**Why** — To improve DevEx and ease of getting started developing on Zora protocol

**Open question** — I don't believe Asks CoreETH is deployed to Goerli yet, only Asks v1.1 and Asks Omnibus. Is this correct? Wanted to flag in case I'm missing something, still learning the v3 architecture =)