### PR TITLE
Checksum Goerli ReserveAuction addresses (docs)

### DIFF
--- a/docs/smart-contracts/modules/ReserveAuctions/intro.mdx
+++ b/docs/smart-contracts/modules/ReserveAuctions/intro.mdx
@@ -35,13 +35,13 @@ You can view all of the code for the `Reserve Auction Modules` in this [GitHub R
 ##### Goerli - 5
 | **Contract**       | **Address**                                |
 | -------------------|--------------------------------------------|
-| CoreETH            | 0x2506d9f5a2b0e1a2619bcce01cd3e7c289a13163 |
-| CoreERC20          | 0x1ee71c10e7dd6c7fbdc891de4e902e041e1f5d33 |
-| FindersETH         | 0x29a6237e646a5a189db197a48cb96fa7944a32a2 |
-| FindersERC20       | 0x36ab5200426715a9dd414513912970cb7d659b3c |
+| CoreETH            | 0x2506D9F5A2b0E1A2619bCCe01CD3e7C289A13163 |
+| CoreERC20          | 0x1Ee71c10e7Dd6c7FbDC891dE4E902e041e1F5d33 |
+| FindersETH         | 0x29a6237e646A5A189dB197A48cB96fa7944A32a2 |
+| FindersERC20       | 0x36aB5200426715a9dD414513912970cb7d659b3C |
 
-<!-- | ListingETH         | 0xfcebe0788d5772df2cbcf5079815de98a4d62b09 |
-| ListingERC20       | 0x517f7721f3c3762f7048e03919761e027d900082 | -->
+<!-- | ListingETH         | 0xfcebE0788D5772Df2CBCF5079815dE98A4d62B09 |
+| ListingERC20       | 0x517F7721F3c3762F7048E03919761E027D900082 | -->
 
 
 ## Reserve Auction Variants


### PR DESCRIPTION
**What** — Update ReserveAuction addresses with EIP-55 checksums
**Why** — For consistency and improved DevEx

Also opened PR in https://github.com/ourzora/v3