### PR TITLE
include max num of files for nouns builder

### DIFF
--- a/docs/smart-contracts/nouns-builder/img-config.mdx
+++ b/docs/smart-contracts/nouns-builder/img-config.mdx
@@ -16,6 +16,7 @@ Note, that the properties for the DAO NFTs are stored in a single folder on IPFS
 Check out the [Example Artwork Toolkit](https://www.figma.com/community/file/1166768320345172833) to learn more about formatting the art for the DAO NFTs.
 
 ### Image Requirments
+- Maximum of 500 files
 - PNG and SVG are the only supported file types
 - 600px x 600px minimum for PNGs and 32px minimum for SVGs
 - Images must be square


### PR DESCRIPTION
Nouns builder currently supports up to 500 files for DAO artwork. Added this into the image requirement section - could maybe use an edit to make it sound better. 