### PR TITLE
Typo fix + added additional faucet link

### DIFF
--- a/docs/guides/builder-deployment.mdx
+++ b/docs/guides/builder-deployment.mdx
@@ -36,7 +36,7 @@ We highly recommend first creating a test DAO on the [Goerli Testnet](https://te
 We also recommend using a personal wallet to create your DAO. If you plan to use a [Safe multisig](https://safe.global/) to create a DAO, please reach out to us on [Twitter](https://twitter.com/nounsbuilder) for support. 
 
 - Visit Testnet **[here](https://testnet.nouns.build/)**.
-- Obtain Goerli ETH **[here](https://faucet.paradigm.xyz/)** or **[here](https://goerlifaucet.com/)**.
+- Obtain Goerli ETH **[here](https://faucet.paradigm.xyz/)**, **[here](https://goerlifaucet.com/)** or **[here](https://faucet.chainstack.com/goerli-faucet)**.
 :::
 
 

--- a/docs/guides/v3-approvals.mdx
+++ b/docs/guides/v3-approvals.mdx
@@ -43,7 +43,7 @@ You can use the following 2 packages to import the ABIs and typechain types (if 
 
 ```javascript
 import { ethers } from "ethers";
-import mainnetZoraAddresses from "@zoralabs/v3/dist/addresses/1.json"; // Mainnet addresses, 5.json would be Geroli Testnet 
+import mainnetZoraAddresses from "@zoralabs/v3/dist/addresses/1.json"; // Mainnet addresses, 5.json would be Goerli Testnet 
 import { IERC721__factory } from "@zoralabs/v3/dist/typechain/factories/IERC721__factory";
 import { IERC20__factory } from "@zoralabs/v3/dist/typechain/factories/IERC20__factory";
 import { ZoraModuleManager__factory } from "@zoralabs/v3/dist/typechain/factories/ZoraModuleManager__factory";
@@ -68,11 +68,11 @@ const erc20Contract = IERC20__factory.connect(nftContractAddress, signer);
 const moduleManagerContract = ZoraModuleManager__factory.connect(mainnetZoraAddresses.ZoraModuleManager, signer);
 ```
 ##### Different Networks
-Note these examples use `Mainnet`, but if you would like to test on `Geroli` then you can update the `networkId` in the import to be `5` to get the `Geroli` addresses.
+Note these examples use `Mainnet`, but if you would like to test on `Goerli` then you can update the `networkId` in the import to be `5` to get the `Goerli` addresses.
 
 `@zoralabs/v3/dist/addresses/1.json` change to `@zoralabs/v3/dist/addresses/5.json` 
 
-You can also get `Geroli` ETH at the faucet [here](https://faucet.paradigm.xyz/) or [here](https://goerlifaucet.com/).
+You can also get `Goerli` ETH at the faucet [here](https://faucet.paradigm.xyz/), [here](https://goerlifaucet.com/) or [here](https://faucet.chainstack.com/goerli-faucet).
 
 ---
 ### Approving a Transfer Helper


### PR DESCRIPTION
"Geroli" fixed to "Goerli", and the Chainstack Goerli faucet has been included among the hyperlinks.