### PR TITLE
fix: 404 links 1155

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -15,7 +15,7 @@ We've created a series of tools that makes it easy to get started building.
 
 - [Zora Network](https://zora.energy/) A Layer 2 designed for putting media onchain
 
-- [Create:](../docs/smart-contracts/creator-tools/intro) Easy to deploy contracts for an NFT project
+- [Smart Contracts:](../docs/smart-contracts/creator-tools/intro) Deploy contracts for an NFT project
 
 - [API:](../docs/zora-api/intro) Retrieve NFT metadata and market data on any ERC-721
 

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -29,9 +29,8 @@ Assets listed below are considered in-scope and are eligible submissions within 
 | zora.energy<br/>- https://bridge.zora.energy/                                                                                                                                              | Website and Applications | In scope | Up to 5 ETH     |
 | docs.zora.co                                                                                                                                                                              | Website and Applications | In scope | Up to 2 ETH     |
 | testnet.zora.co                                                                                                                                                                           | Website and Applications | In scope | Up to 2 ETH     ||
-| https://github.com/ourzora/zora-drops-contracts                                                                                                                                           | Smart Contract           | In scope | Up to 25 ETH    |
-| https://github.com/ourzora/zora-1155-contracts                                                                                                                                            | Smart Contract           | In scope | Up to 25 ETH    |
-| https://github.com/ourzora/protocol-rewards                                                                                                                                               | Smart Contract           | In scope | Up to 25 ETH    |
+| https://github.com/ourzora/zora-protocol     
+| https://github.com/ourzora/zora-drops-contracts                                                                                                                                       | Smart Contract           | In scope | Up to 25 ETH    |
 | https://github.com/ourzora/zdk                                                                                                                                                            | Smart Contract           | In scope | Up to 3 ETH     |                                                               
 
 *Please note: All bounty rewards will be denoted and paid out as USDC. Rewards will require the recipient to have an erc20 wallet address.*

--- a/docs/smart-contracts/creator-tools/B2R1155.mdx
+++ b/docs/smart-contracts/creator-tools/B2R1155.mdx
@@ -17,7 +17,7 @@ Features:
 - Supports Specific TokenId Ranges
 - ETH Payments
 
-[Source Code](https://github.com/ourzora/zora-1155-contracts/tree/main/src/minters/redeem)
+[Source Code](https://github.com/ourzora/zora-protocol/tree/main/packages/1155-contracts/src/minters/redeem)
 
 ## Factory Contract
 For security reasons, each Zora 1155 contract needs to have a unique burn to redeem minter deployed for it.

--- a/docs/smart-contracts/creator-tools/Creating1155Token.mdx
+++ b/docs/smart-contracts/creator-tools/Creating1155Token.mdx
@@ -3,16 +3,20 @@ title: Creating a Token
 ---
 ---
 
-Calling `setupNewToken` on a deployed 1155 contract will create a new token. 
+Calling `setupNewTokenWithCreateReferral` on a deployed 1155 contract will create a new token.
+In addition, by passing in your address as the `createReferral` will yield you rewards from those mints. 
 All tokens start at tokenId 1 and increment up. 
 tokenId 0 is reserved for the contract information.
 `maxSupply` should be set to `MAX_INT` for an open edition.
 
+[View source code here.](https://github.com/ourzora/zora-protocol/blob/main/packages/1155-contracts/src/nft/ZoraCreator1155Impl.sol#L272C1-L276C101)
+
 ```
-function setupNewToken(
-    string memory _uri,
-    uint256 maxSupply
-) public nonReentrant returns (uint256) 
+function setupNewTokenWithCreateReferral(
+    string calldata newURI,
+    uint256 maxSupply,
+    address createReferral
+) public onlyAdminOrRole(CONTRACT_BASE_ID, PERMISSION_BIT_MINTER) nonReentrant returns (uint256)
 ```
 
 

--- a/docs/smart-contracts/creator-tools/Deploy1155Contract.mdx
+++ b/docs/smart-contracts/creator-tools/Deploy1155Contract.mdx
@@ -7,10 +7,9 @@ All 1155 contracts created from Zora are deployed by calling a central factory c
 When calling this factory it will deploy a minimal proxy contract that is upgradeable.
 All upgrades are opt-in and must be done manually on a per contract basis by the user.
 
-- [Factory Contract Code](https://github.com/ourzora/zora-creator-contracts/blob/main/src/factory/ZoraCreator1155FactoryImpl.sol)
-- [Mainnet Addresses](https://github.com/ourzora/zora-creator-contracts/blob/main/addresses/1.json)
-- [Goerli Addresses](https://github.com/ourzora/zora-creator-contracts/blob/main/addresses/5.json)
-
+- [Factory Contract Code](https://github.com/ourzora/zora-protocol/blob/main/packages/1155-contracts/src/factory/ZoraCreator1155FactoryImpl.sol)
+- [Deployed Addresses](https://github.com/ourzora/zora-protocol/tree/main/packages/protocol-deployments/addresses)
+- Factory Proxy Address 0x777777C338d93e2C7adf08D102d45CA7CC4Ed021 on all networks
 
 ## Calling the Factory Contract
 The `createContract` function on the factory is responsible for deploying a new 1155 contract. 
@@ -24,10 +23,10 @@ Such as creating a token and sale in the same transaction as deploying the contr
 - `setupActions`: The actions to perform on the new contract upon initialization (optional)
 ```
 function createContract(
-    string memory contractURI,
+    string calldata newContractURI,
     string calldata name,
     ICreatorRoyaltiesControl.RoyaltyConfiguration memory defaultRoyaltyConfiguration,
-    address defaultAdmin,
+    address payable defaultAdmin,
     bytes[] calldata setupActions
 ) external returns (address)
 ```

--- a/docs/smart-contracts/creator-tools/Minting1155.mdx
+++ b/docs/smart-contracts/creator-tools/Minting1155.mdx
@@ -3,8 +3,10 @@ title: Minting Tokens
 ---
 ---
 
+[View Source Code](https://github.com/ourzora/zora-protocol/blob/main/packages/1155-contracts/src/nft/ZoraCreator1155Impl.sol#L426)
+
 ## Zora Mint Fee
-Zora charges a small fee (~$1) to a user minting an NFT. 
+Zora charges a small fee for minting an NFT. 
 There is no charge to the creator, all the funds from the sales go to the creator.
 Lastly, the mint fee doesn't apply to admin minted NFT (airdropping).
 
@@ -13,7 +15,10 @@ You can read more about the Zora mint fee [here](https://support.zora.co/en/arti
 
 `function mintFee() external view returns (uint256)`
 
-## Mint Function
+## Mint Function with Rewards
+
+Referring a mint and passing it in as the `mintReferral` with give a reward to the person or platform that referrs the mint.
+View the rewards section for more information.
 
 Purchase tokens given a minter contract and minter arguments
 - `minter`: The minter contract to use
@@ -23,12 +28,13 @@ Purchase tokens given a minter contract and minter arguments
 
 *The minter arguments are different for each minter contract and are listed in the section.
 ```
-function mint(
-    IMinter1155 minter, 
-    uint256 tokenId, 
-    uint256 quantity, 
-    bytes calldata minterArguments
-) external payable 
+function mintWithRewards(
+    IMinter1155 minter,
+    uint256 tokenId,
+    uint256 quantity,
+    bytes calldata minterArguments,
+    address mintReferral
+) external payable nonReentrant 
 ```
 
 ## Minter Strategy Contracts
@@ -37,9 +43,8 @@ It lives in separate contracts called minters.
 To mint a token the `mint` function is called on the main 1155 contract and then minter checks if the user should be able to mint.
 Then the minter tells the main 1155 contract if it should mint or not.
 
-- [Minters Code](https://github.com/ourzora/zora-creator-contracts/tree/main/src/minters)
-- [Mainnet Addresses](https://github.com/ourzora/zora-creator-contracts/blob/main/addresses/1.json)
-- [Goerli Addresses](https://github.com/ourzora/zora-creator-contracts/blob/main/addresses/5.json)
+- [Minters Code](https://github.com/ourzora/zora-protocol/tree/main/packages/1155-contracts/src/minters)
+- [Deployed Addresses](https://github.com/ourzora/zora-protocol/tree/main/packages/protocol-deployments/addresses)
 
 *Note, that the minter arguments are type `bytes`
 

--- a/docs/smart-contracts/creator-tools/Permissions1155.mdx
+++ b/docs/smart-contracts/creator-tools/Permissions1155.mdx
@@ -3,6 +3,8 @@ title: Permissions
 ---
 ---
 
+[View Source Code](https://github.com/ourzora/zora-protocol/blob/main/packages/1155-contracts/src/nft/ZoraCreator1155Impl.sol#L329)
+
 ## Admin and Minter Role
 - `Admin`: Can update sales, airdrop tokens, metadata, and withdraw ETH
 - `Minter`: Can mint and airdrop tokens

--- a/docs/smart-contracts/creator-tools/Selling1155.mdx
+++ b/docs/smart-contracts/creator-tools/Selling1155.mdx
@@ -8,9 +8,8 @@ Once a token has been created, it can then be put up for sale.
 Minter strategy contracts are separate contracts that hold minting logic, but the main 1155 is called for minting. 
 Check out the [minting](./Minting1155) section to learn more about minters.
 
-- [Minter Strategy Code](https://github.com/ourzora/zora-creator-contracts/tree/main/src/minters)
-- [Mainnet Addresses](https://github.com/ourzora/zora-creator-contracts/blob/main/addresses/1.json)
-- [Goerli Addresses](https://github.com/ourzora/zora-creator-contracts/blob/main/addresses/5.json)
+- [Minter Strategy Code](https://github.com/ourzora/zora-protocol/tree/main/packages/1155-contracts/src/minters)
+- [Addresses](https://github.com/ourzora/zora-protocol/tree/main/packages/protocol-deployments/addresses)
 
 To create a sale you must use the `callSale` function on the 1155 contract.
 This will set the sale in the appropriate minter.
@@ -59,12 +58,9 @@ struct MerkleSaleSettings {
 }
 ```
 
-## Supply Royalty
-When selling a token, a creator has the opportunity to receive a certain percentage of the tokens minted for themselves. 
-These tokens are minted to the `royaltyRecipient` address as the mints occur.
-As tokens are minted, an amount is minted to them as the mints occur using the `royaltyMintSchedule`.
+## Royalty
+Royalties are set on the main 1155 contract.
 
-- `royaltyMintSchedule`: 1/N tokens are minted to the royalty recipient
 - `royaltyBPS`: The royalty amount in basis points for secondary sales.
 - `royaltyRecipient`: The address that will receive the royalty payments.
 

--- a/docs/smart-contracts/creator-tools/factories.mdx
+++ b/docs/smart-contracts/creator-tools/factories.mdx
@@ -4,56 +4,60 @@ title: Factory Addresses
 
 ---
 
+The Zora factory proxy has been deployed at a deterministic address on all networks.
+
+[View all contract addresses here.](https://github.com/ourzora/zora-protocol/tree/main/packages/protocol-deployments/addresses)
+[1155 Factory Code](https://github.com/ourzora/zora-protocol/blob/main/packages/1155-contracts/src/factory/ZoraCreator1155FactoryImpl.sol)
 #### Zora (Chain Id: 7777777)
 
 | Type     | Address                                    |
 | -------- | ------------------------------------------ |
+| ERC-1155 | 0x777777C338d93e2C7adf08D102d45CA7CC4Ed021 |
 | ERC-721  | 0xA2c2A96A232113Dd4993E8b048EEbc3371AE8d85 |
-| ERC-1155 | 0x35ca784918bf11692708c1D530691704AAcEA95E |
 
 #### Zora Goerli (Chain Id: 999)
 
 | Type     | Address                                    |
 | -------- | ------------------------------------------ |
+| ERC-1155 | 0x777777C338d93e2C7adf08D102d45CA7CC4Ed021 |
 | ERC-721  | 0xeB29A4e5b84fef428c072debA2444e93c080CE87 |
-| ERC-1155 | 0x6a357139C1bcDcf0B3AB9bC447932dDdcb956703 |
 
 #### Mainnet (Chain Id: 1)
 
 | Type     | Address                                    |
 | -------- | ------------------------------------------ |
+| ERC-1155 | 0x777777C338d93e2C7adf08D102d45CA7CC4Ed021 |
 | ERC-721  | 0xF74B146ce44CC162b601deC3BE331784DB111DC1 |
-| ERC-1155 | 0xA6C5f2DE915240270DaC655152C3f6A91748cb85 |
 
 #### Goerli (Chain Id: 5)
 
 | Type     | Address                                    |
 | -------- | ------------------------------------------ |
+| ERC-1155 | 0x777777C338d93e2C7adf08D102d45CA7CC4Ed021 |
 | ERC-721  | 0xb9583D05Ba9ba8f7F14CCEe3Da10D2bc0A72f519 |
-| ERC-1155 | 0x8732b4bCa198509bB9c40f9a24638Be1eaB7D30c |
 
 #### Base (Chain Id: 8453)
 | Type     | Address                                    |
 | -------- | ------------------------------------------ |
+| ERC-1155 | 0x777777C338d93e2C7adf08D102d45CA7CC4Ed021 |
 | ERC-721  | 0x58C3ccB2dcb9384E5AB9111CD1a5DEA916B0f33c |
-| ERC-1155 | 0x9b24FD165a371042e5CA81e8d066d25CAD11EDE7 |
 
 #### Base Goerli (Chain Id: 84531)
 
 | Type     | Address                                    |
 | -------- | ------------------------------------------ |
+| ERC-1155 | 0x777777C338d93e2C7adf08D102d45CA7CC4Ed021 |
 | ERC-721  | 0x87cfd516c5ea86e50b950678CA970a8a28de27ac |
-| ERC-1155 | 0x9b24FD165a371042e5CA81e8d066d25CAD11EDE7 |
 
 #### Optimism (Chain Id: 10)
 | Type     | Address                                    |
 | -------- | ------------------------------------------ |
+| ERC-1155 | 0x777777C338d93e2C7adf08D102d45CA7CC4Ed021 |
 | ERC-721  | 0x7d1a46c6e614A0091c39E102F2798C27c1fA8892 |
-| ERC-1155 | 0x78b524931e9d847c40BcBf225c25e154a7B05fDA |
 
 #### Optimism Goerli (Chain Id: 420)
 
 | Type     | Address                                    |
 | -------- | ------------------------------------------ |
+| ERC-1155 | 0x777777C338d93e2C7adf08D102d45CA7CC4Ed021 |
 | ERC-721  | 0x3C1ebcF36Ca9DD9371c9aA99c274e4988906c6E3 |
-| ERC-1155 | 0xb0C56317E9cEBc6E0f7A59458a83D0A9ccC3e955 |

--- a/docs/smart-contracts/creator-tools/intro.mdx
+++ b/docs/smart-contracts/creator-tools/intro.mdx
@@ -14,30 +14,13 @@ import TabItem from '@theme/TabItem'
 These contracts allow anyone to deploy an NFT collection in seconds.
 In addition, these contracts **provide built-in sales mechanics**, making it easy to both deploy a collection and sell the initial mints.
 
-- [Goerli Testnet UI](https://testnet.zora.co/) - Test out deploying a contract
-- [1155 Contract Code](https://github.com/ourzora/zora-creator-contracts/tree/main/src)
-- [721 Contract Code](https://github.com/ourzora/zora-drops-contracts/tree/main/src)
+- [Zora Testnet UI](https://testnet.zora.co/)
+- [1155 Contract Code](https://github.com/ourzora/zora-protocol/tree/main/packages/1155-contracts)
 
-## Contract Addresses
-
-### 1155 Contracts
-- [Mainnet](https://github.com/ourzora/zora-creator-contracts/blob/main/addresses/1.json)
-- [Goerli](https://github.com/ourzora/zora-creator-contracts/blob/main/addresses/5.json)
-
-### 721 Contracts
-- [Mainnet](https://github.com/ourzora/zora-drops-contracts/blob/main/addresses/1.json)
-- [Goerli](https://github.com/ourzora/zora-drops-contracts/blob/main/addresses/5.json)
-
-
-## Edition vs Drop
-
-These contracts can make two different types of NFT collections:
-
-- `Edition`: All the NFTs share the same media asset.
-- `Drop`: All the NFTs have individual pieces of media.
-
+## Deployment Addresses
+[Files are numbered by chainId of the network deployment.](https://github.com/ourzora/zora-protocol/tree/main/packages/protocol-deployments/addresses)
 
 ## 1155 vs 721
 
-- `1155`: Editions are stored in the same contract. Recommended for creating editions.
-- `721`: All NFTs have unique id numbers. Recommended for creating drops.
+- `1155`: Multiple editions are stored in the same contract.
+- `721`: All NFTs have unique id numbers. 

--- a/docs/smart-contracts/creator-tools/rewards.mdx
+++ b/docs/smart-contracts/creator-tools/rewards.mdx
@@ -5,13 +5,21 @@ title: Protocol Rewards
 
 ---
 
+[Rewards escrow contract code](https://github.com/ourzora/zora-protocol/tree/main/packages/protocol-rewards)
+
 ## Introduction
 
 At Zora, we are passionate about providing the best experience to create and earn onchain.
-**Protocol Rewards** is a split of our 0.000777 ETH mint fee allowing:
+**Protocol Rewards** is a split of our the Zora mint fee allowing:
 
 - Creators to monetize their work
 - Developers to earn from NFT mints and creations they facilitate
+
+## Address
+
+Rewards v1.1 is deployed at the same address on all networks.
+
+0x7777777F279eba3d3Ad8F4E708545291A6fDBA8B
 
 ## Fee Split (Per Mint)
 
@@ -52,43 +60,7 @@ The creator's total ETH generated from rewards is aggregated into an [escrow con
 
 The create referral reward is paid out to the developer or platform that referred the creator to deploy their NFT collection using Zora's contracts.
 
-#### Creating an ERC-721 Token
-
-The `createReferral` address is the parameter to specify the reward recipient when calling the `createEditionWithReferral` or `createDropWithReferral` functions. 
-More info on the other parameters from our standard `createEdition` and `createDrop` functions can be found [here](./ZoraNFTCreator#creating-an-nft-contract).
-
-```
-function createEditionWithReferral(
-    string memory name,
-    string memory symbol,
-    uint64 editionSize,
-    uint16 royaltyBPS,
-    address payable fundsRecipient,
-    address defaultAdmin,
-    IERC721Drop.SalesConfiguration memory saleConfig,
-    string memory description,
-    string memory animationURI,
-    string memory imageURI,
-    address createReferral
-) external returns (address)
-```
-
-```
-function createDropWithReferral(
-    string memory name,
-    string memory symbol,
-    address defaultAdmin,
-    uint64 editionSize,
-    uint16 royaltyBPS,
-    address payable fundsRecipient,
-    IERC721Drop.SalesConfiguration memory saleConfig,
-    string memory metadataURIBase,
-    string memory metadataContractURI,
-    address createReferral
-) external returns (address)
-```
-
-#### Creating an ERC-1155 Token
+#### Creating an ERC-1155 Token with Rewards
 
 The `createReferral` address is specified upon token creation.
 
@@ -104,20 +76,7 @@ function setupNewTokenWithCreateReferral(
 
 The mint referral reward is paid out to the party that referred the collector to mint an NFT.
 
-#### ERC-721 Minting
-
-The `mintReferral` address is the parameter to specify as the reward recipient upon mint.
-
-```
-function mintWithRewards(
-    address recipient, 
-    uint256 quantity, 
-    string calldata comment, 
-    address mintReferral
-)
-```
-
-#### ERC-1155 Minting
+#### ERC-1155 Minting with Rewards
 
 ```
 function mintWithRewards(
@@ -133,6 +92,11 @@ function mintWithRewards(
 Rewards must be withdrawn from the escrow contract, which the address can be found [here](https://github.com/ourzora/protocol-rewards/tree/main/addresses).
 ```
 function withdraw(address to, uint256 amount)
+```
+
+Withdraw for another address directly.
+```
+function withdrawFor(address to, uint256 amount) 
 ```
 
 ```

--- a/docs/smart-contracts/intro.mdx
+++ b/docs/smart-contracts/intro.mdx
@@ -9,11 +9,10 @@ title: Introduction
 
 ---
 
-Zora is a decentralized protocol where anyone can permissionlessly buy, sell, and create. 
+Permissionlessly create open edition NFTs. 
 
-- [Nouns Builder](./nouns-builder/intro): Deploy a DAO in minutes
-- [Create Tools](./creator-tools/intro): Create an NFT collection
-- [Zora V3](./modules/intro): NFT Market Functionality
+- [Core Smart Contracts](./creator-tools/intro): Docs on our core contracts.
+- [Protocol Github](https://github.com/ourzora/zora-protocol/tree/main): View source code for Zora contracts.
 
 All of our repositories are open source with either the [MIT License](https://opensource.org/licenses/MIT) or the [GPL-3.0 License](https://www.gnu.org/licenses/gpl-3.0.en.html).
 Zora's tools are in the public domain, as such anyone can view and contribute to every aspect.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,7 +27,7 @@ module.exports = {
         },
         {
           position: 'left',
-          label: 'Create',
+          label: 'Contracts',
           to: '/docs/smart-contracts/creator-tools/intro',
         },
         {

--- a/sidebars.js
+++ b/sidebars.js
@@ -23,10 +23,11 @@ module.exports = {
   createtools: [
     {
       type: 'category',
-      label: 'Create NFT Collection',
+      label: 'NFT Smart Contracts',
       collapsed: true,
       items: [
         'smart-contracts/creator-tools/intro',
+        'smart-contracts/creator-tools/factories',
         'smart-contracts/creator-tools/rewards',
         {
           type: 'category',
@@ -53,7 +54,7 @@ module.exports = {
             'smart-contracts/creator-tools/DropMetadataRenderer',
           ],
         },
-        'smart-contracts/creator-tools/factories'
+        
       ],
     },
   ],


### PR DESCRIPTION
New protocol repo had broken 1155 contract and rewards related gh links.
Updated some of the 1155 functions to be the rewards function call.