### PR TITLE
Fix typos

### DIFF
--- a/docs/smart-contracts/creator-tools/ERC721Drop.mdx
+++ b/docs/smart-contracts/creator-tools/ERC721Drop.mdx
@@ -55,7 +55,7 @@ The max size is set when creating the contract and specifying the `editionSize`.
 
 #### Open Edition
 An open edition collection has no max amount but instead has a certain time window where minting is open. 
-However, once the period is over then no one can publically mint anymore.
+However, once the period is over then no one can publicly mint anymore.
 
 Note, `finalizeOpenEdition` **must be called by an admin** once the minting window has closed to make sure that it's not possible to mint any more NFTs from the contract.
 

--- a/docs/smart-contracts/creator-tools/Minting1155.mdx
+++ b/docs/smart-contracts/creator-tools/Minting1155.mdx
@@ -58,7 +58,7 @@ Mint NFTs for a specific ETH price.
 *Note, the payment amount of ETH must be set an override if using wagmi or ethers.js. 
 
 #### Getting the Mint Price 
-Caling the `sale` function on the fixed-price minter will return the price for a specific token.
+Calling the `sale` function on the fixed-price minter will return the price for a specific token.
 `function sale(address tokenContract, uint256 tokenId) ` 
 
 ### Merkle Proof Strategy

--- a/docs/smart-contracts/nouns-builder/governance.mdx
+++ b/docs/smart-contracts/nouns-builder/governance.mdx
@@ -34,7 +34,7 @@ For example, if the Proposal Threshold is set to 100 BPS and there are 500 total
 ---
 
 ## Min and Max Values
-As a precaution, Nouns Builder has put guards in place to make sure that goverance can't set voting parameters to unreasonable values.
+As a precaution, Nouns Builder has put guards in place to make sure that governance can't set voting parameters to unreasonable values.
 Listed below are the min and max values possible for each governance parameter.
 
 ##### Proposal Threshold 
@@ -188,7 +188,7 @@ function veto(bytes32 _proposalId) external
 #### Updating and Removing Veto
 ```
 /// @notice Updates the vetoer
-/// @param newVetoer The new vetoer addresss
+/// @param newVetoer The new vetoer address
 function updateVetoer(address newVetoer) external;
 
 /// @notice Burns the vetoer

--- a/docs/smart-contracts/nouns-builder/img-config.mdx
+++ b/docs/smart-contracts/nouns-builder/img-config.mdx
@@ -15,7 +15,7 @@ Note, that the properties for the DAO NFTs are stored in a single folder on IPFS
 
 Check out the [Example Artwork Toolkit](https://www.figma.com/community/file/1166768320345172833) to learn more about formatting the art for the DAO NFTs.
 
-### Image Requirments
+### Image Requirements
 - Maximum of 500 files
 - PNG and SVG are the only supported file types
 - 600px x 600px minimum for PNGs and 32px minimum for SVGs

--- a/docs/zora-api/intro.mdx
+++ b/docs/zora-api/intro.mdx
@@ -63,7 +63,7 @@ Anyone can use the API **without an API key** as long as the application is maki
 | Less than 120 requests per minute  | **No Key Needed**           |
 | Greater than 120 requests per minute   | Key Needed              |
 
-You can get an API key [here](https://keys.api.zora.co/) if your needs require **greater than 120 requests per mintue.**
+You can get an API key [here](https://keys.api.zora.co/) if your needs require **greater than 120 requests per minute.**
 To access the API with a key, add a header in your requests with the key `X-API-KEY` .
 
 ```

--- a/docs/zora-network/contracts.mdx
+++ b/docs/zora-network/contracts.mdx
@@ -33,7 +33,7 @@ forge create src/MyContract.sol:MyContract --chain-id 999 --rpc-url https://test
 
 You can also verify a pre-existing contract with the `forge verify-contract` command using the same flags (`--verifier` and `--verifier-url`).
 
-Note: Zora uses Blockscout which requires apending `\?` to the end of the API url like in the example above. More details [here](https://github.com/foundry-rs/foundry/issues/5160).
+Note: Zora uses Blockscout which requires appending `\?` to the end of the API url like in the example above. More details [here](https://github.com/foundry-rs/foundry/issues/5160).
 
 ## Hardhat
 


### PR DESCRIPTION
Hello
I fixed some typos in the documentation

1. ERC721Drop.mdx
2. Minting1155.mdx
3. governance.mdx
4. img-config.mdx
5. intro.mdx
6. contracts.mdx